### PR TITLE
Support for querying job status by unique key

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -57,6 +57,16 @@ if test "$PHP_GEARMAN" != "no"; then
     -L$GEARMAN_LIB_DIR -R$GEARMAN_LIB_DIR
   ])
 
+  PHP_CHECK_LIBRARY(gearman, gearman_client_unique_status,
+  [
+    PHP_ADD_LIBRARY_WITH_PATH(gearman, $GEARMAN_LIB_DIR, GEARMAN_SHARED_LIBADD)
+    AC_DEFINE(HAVE_GEARMAN, 1, [Whether you have gearman])
+  ],[
+    AC_MSG_ERROR([libgearman version 1.1.0 or later required])
+  ],[
+    -L$GEARMAN_LIB_DIR -R$GEARMAN_LIB_DIR
+  ])
+
   PHP_SUBST(GEARMAN_SHARED_LIBADD)
 
   PHP_ADD_INCLUDE($GEARMAN_INC_DIR)


### PR DESCRIPTION
Brian Aker added in this feature a while back to the libgearman client API: gearman_client_unique_status().

This patch adds support to the PHP API by adding 2 new methods: gearman_client_job_status_by_unique_key and jobStatusByUniqueKey.
