### PR TITLE
Delete all codes about gearman_worker_set_server_option.

### DIFF
--- a/php_gearman.c
+++ b/php_gearman.c
@@ -1908,10 +1908,6 @@ PHP_FUNCTION(gearman_client_add_server) {
 		RETURN_FALSE;
 	}
 
-	if (!gearman_client_set_server_option(&(obj->client), "exceptions", (sizeof("exceptions") - 1))) {
-	    GEARMAN_EXCEPTION("Failed to set exception option", 0);
-	}
-
 	RETURN_TRUE;
 }
 /* }}} */
@@ -1932,10 +1928,6 @@ PHP_FUNCTION(gearman_client_add_servers) {
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "%s",
 						 gearman_client_error(&(obj->client)));
 		RETURN_FALSE;
-	}
-
-	if (!gearman_client_set_server_option(&(obj->client), "exceptions", (sizeof("exceptions") - 1))) {
-	    GEARMAN_EXCEPTION("Failed to set exception option", 0);
 	}
 
 	RETURN_TRUE;
@@ -3385,10 +3377,6 @@ PHP_FUNCTION(gearman_worker_add_server) {
 		RETURN_FALSE;
 	}
 
-	if (! gearman_worker_set_server_option(&(obj->worker), "exceptions", (sizeof("exceptions") - 1))) {
-		GEARMAN_EXCEPTION("Failed to set exception option", 0);
-	}
-
 	RETURN_TRUE;
 }
 /* }}} */
@@ -3409,10 +3397,6 @@ PHP_FUNCTION(gearman_worker_add_servers) {
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "%s",
 						 gearman_worker_error(&(obj->worker)));
 		RETURN_FALSE;
-	}
-
-	if (! gearman_worker_set_server_option(&(obj->worker), "exceptions", (sizeof("exceptions") - 1))) {
-		GEARMAN_EXCEPTION("Failed to set exception option", 0);
 	}
 
 	RETURN_TRUE;


### PR DESCRIPTION
Gearman_worker_set_server_option need network io. When any gearman
server is down, "Failed to set exception option" on connect. So I
delete gearman_worker_set_server_option. We can use this option when
startting gearmand.
